### PR TITLE
Toggle arrow color on click

### DIFF
--- a/src/Render.php
+++ b/src/Render.php
@@ -104,7 +104,11 @@ class Render
                      });
                 </script>"
                 : '',
-            '<script>$(document).on("click", "path", e => { e.currentTarget.style.stroke = e.currentTarget.style.stroke ? "" : "red"; })</script>',
+            '<script>
+                $(document).on("click", "path", e => {
+                    e.currentTarget.style.stroke = e.currentTarget.style.stroke ? "" : "red";
+                });
+            </script>',
             '</body>',
             '</html>',
         ]);

--- a/src/Render.php
+++ b/src/Render.php
@@ -104,6 +104,7 @@ class Render
                      });
                 </script>"
                 : '',
+            '<script>$(document).on("click", "path", e => { e.currentTarget.style.stroke = e.currentTarget.style.stroke ? "" : "red"; })</script>',
             '</body>',
             '</html>',
         ]);


### PR DESCRIPTION
When there are a lot of arrows and nodes, it's very hard to follow a single arrow. The stroke-size change on hover helps, but it has two weaknesses:
  1. the arrow still blends with others which are right next to it.
  2. when the diagram is big and the arrow is very large, scrolling will always turn off the hover state.

The color change makes the arrow stand out and it persists through scrolling.