### PR TITLE
Link styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JBZoo / Mermaid-PHP
 
-[![Build Status](https://travis-ci.org/JBZoo/Mermaid-PHP.svg?branch=master)](https://travis-ci.org/JBZoo/Mermaid-PHP)    [![Coverage Status](https://coveralls.io/repos/JBZoo/Mermaid-PHP/badge.svg)](https://coveralls.io/github/JBZoo/Mermaid-PHP)    [![Psalm Coverage](https://shepherd.dev/github/JBZoo/Mermaid-PHP/coverage.svg)](https://shepherd.dev/github/JBZoo/Mermaid-PHP)    [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/jbzoo/mermaid-php/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/jbzoo/mermaid-php/?branch=master)    [![CodeFactor](https://www.codefactor.io/repository/github/jbzoo/mermaid-php/badge)](https://www.codefactor.io/repository/github/jbzoo/mermaid-php/issues)    [![PHP Strict Types](https://img.shields.io/badge/strict__types-%3D1-brightgreen)](https://www.php.net/manual/en/language.types.declarations.php#language.types.declarations.strict)    
+[![Build Status](https://travis-ci.org/JBZoo/Mermaid-PHP.svg?branch=master)](https://travis-ci.org/JBZoo/Mermaid-PHP)    [![Coverage Status](https://coveralls.io/repos/JBZoo/Mermaid-PHP/badge.svg)](https://coveralls.io/github/JBZoo/Mermaid-PHP)    [![Psalm Coverage](https://shepherd.dev/github/JBZoo/Mermaid-PHP/coverage.svg)](https://shepherd.dev/github/JBZoo/Mermaid-PHP)    [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/jbzoo/mermaid-php/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/jbzoo/mermaid-php/?branch=master)    [![CodeFactor](https://www.codefactor.io/repository/github/jbzoo/mermaid-php/badge)](https://www.codefactor.io/repository/github/jbzoo/mermaid-php/issues)    [![PHP Strict Types](https://img.shields.io/badge/strict__types-%3D1-brightgreen)](https://www.php.net/manual/en/language.types.declarations.php#language.types.declarations.strict)
 [![Stable Version](https://poser.pugx.org/jbzoo/mermaid-php/version)](https://packagist.org/packages/jbzoo/mermaid-php)    [![Latest Unstable Version](https://poser.pugx.org/jbzoo/mermaid-php/v/unstable)](https://packagist.org/packages/jbzoo/mermaid-php)    [![Dependents](https://poser.pugx.org/jbzoo/mermaid-php/dependents)](https://packagist.org/packages/jbzoo/mermaid-php/dependents?order_by=downloads)    [![GitHub Issues](https://img.shields.io/github/issues/jbzoo/mermaid-php)](https://github.com/JBZoo/Mermaid-PHP/issues)    [![Total Downloads](https://poser.pugx.org/jbzoo/mermaid-php/downloads)](https://packagist.org/packages/jbzoo/mermaid-php/stats)    [![GitHub License](https://img.shields.io/github/license/jbzoo/mermaid-php)](https://github.com/JBZoo/Mermaid-PHP/blob/master/LICENSE)
 
 
@@ -32,7 +32,7 @@ $subGraph1
     ->addLink(new Link($nodeE, $nodeD))
     ->addLink(new Link($nodeB, $nodeC))
     ->addLink(new Link($nodeC, $nodeD, 'A double quote:"'))
-    ->addLink(new Link($nodeC, $nodeE, 'A dec char:♥'))
+    ->addLink(new Link($nodeC, $nodeE, 'A dec char:♥', Link::ARROW, 'stroke:blue,stroke-width:4px'))
     ->addLink(new Link($nodeA, $nodeB, ' Link text<br>/\\!@#$%^&*()_+><\' " '));
 
 $subGraph2
@@ -48,7 +48,7 @@ $htmlCode = $graph->renderHtml([
     'show-zoom' => true
 ]); // Get result as HTML code for debugging
 
-echo $graph->getLiveEditorUrl(); // Get link to live editor 
+echo $graph->getLiveEditorUrl(); // Get link to live editor
 ```
 
 ### Result
@@ -73,6 +73,7 @@ graph TB;
         alone-->C;
     end
 linkStyle default interpolate basis;
+linkStyle 3 stroke:blue,stroke-width:4px;
 ```
 
 
@@ -100,6 +101,6 @@ MIT
 - [Composer-Graph](https://github.com/JBZoo/Composer-Graph) - Dependency graph visualization of composer.json based on mermaid-js.
 - [Utils](https://github.com/JBZoo/Utils) - Collection of useful PHP functions, mini-classes, and snippets for every day.
 - [Image](https://github.com/JBZoo/Image) - Package provides object-oriented way to manipulate with images as simple as possible.
-- [Data](https://github.com/JBZoo/Data) - Extended implementation of ArrayObject. Use files as config/array. 
+- [Data](https://github.com/JBZoo/Data) - Extended implementation of ArrayObject. Use files as config/array.
 - [Retry](https://github.com/JBZoo/Retry) - Tiny PHP library providing retry/backoff functionality with multiple backoff strategies and jitter support.
 - [SimpleTypes](https://github.com/JBZoo/SimpleTypes) - Converting any values and measures - money, weight, exchange rates, length, ...

--- a/src/Graph.php
+++ b/src/Graph.php
@@ -48,7 +48,7 @@ class Graph
      */
     protected $params = [
         'abc_order' => false,
-        'title'     => 'Graph',
+        'title' => 'Graph',
         'direction' => self::TOP_BOTTOM,
     ];
 
@@ -75,7 +75,7 @@ class Graph
 
     /**
      * @param bool $isMainGraph
-     * @param int  $shift
+     * @param int $shift
      * @return string
      * @SuppressWarnings(PHPMD.NPathComplexity)
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
@@ -107,8 +107,11 @@ class Graph
 
         if (count($this->links) > 0) {
             $tmp = [];
-            foreach ($this->links as $link) {
+            $i = 0;
+            foreach ($this->links as $idx => $link) {
                 $tmp[] = $spacesSub . $link;
+                $this->links[$idx]->setIndex($i);
+                $i++;
             }
             if ($this->params['abc_order']) {
                 sort($tmp);
@@ -126,6 +129,14 @@ class Graph
         if ($isMainGraph && count($this->styles) > 0) {
             foreach ($this->styles as $style) {
                 $result[] = $spaces . $style . ';';
+            }
+        }
+
+        if (count($this->links) > 0) {
+            foreach ($this->links as $link) {
+                if ($style = $link->getStyle()) {
+                    $result[] = $spaces . $style . ';';
+                }
             }
         }
 
@@ -160,7 +171,7 @@ class Graph
      * @param string $sourceNodeId
      * @param string $targetNodeId
      * @param string $text
-     * @param int    $style
+     * @param int $style
      * @return Graph
      */
     public function addLinkByIds(
@@ -168,7 +179,8 @@ class Graph
         string $targetNodeId,
         string $text = '',
         int $style = Link::ARROW
-    ): Graph {
+    ): Graph
+    {
         $source = $this->getNode($sourceNodeId);
         if (!$source) {
             throw new Exception("Source node id=\"{$sourceNodeId}\" not found");

--- a/src/Link.php
+++ b/src/Link.php
@@ -23,16 +23,16 @@ namespace JBZoo\MermaidPHP;
  */
 class Link
 {
-    public const ARROW  = 1;
-    public const LINE   = 2;
+    public const ARROW = 1;
+    public const LINE = 2;
     public const DOTTED = 3;
-    public const THICK  = 4;
+    public const THICK = 4;
 
     protected const TEMPLATES = [
-        self::ARROW  => ['-->', '-->|%s|'],
-        self::LINE   => [' --- ', '---|%s|'],
+        self::ARROW => ['-->', '-->|%s|'],
+        self::LINE => [' --- ', '---|%s|'],
         self::DOTTED => ['-.->', '-. %s .-> '],
-        self::THICK  => [' ==> ', ' == %s ==> '],
+        self::THICK => [' ==> ', ' == %s ==> '],
     ];
 
     /**
@@ -48,7 +48,7 @@ class Link
     /**
      * @var int
      */
-    protected $style = self::ARROW;
+    protected $type = self::ARROW;
 
     /**
      * @var string
@@ -56,17 +56,29 @@ class Link
     protected $text = '';
 
     /**
-     * @param Node   $sourceNode
-     * @param Node   $targetNode
-     * @param string $text
-     * @param int    $style
+     * @var ?string
      */
-    public function __construct(Node $sourceNode, Node $targetNode, string $text = '', int $style = self::ARROW)
+    protected $style = '';
+
+    /**
+     * @var int|null
+     */
+    protected $index = null;
+
+    /**
+     * @param Node $sourceNode
+     * @param Node $targetNode
+     * @param string $text
+     * @param int $type
+     * @param string|null $style
+     */
+    public function __construct(Node $sourceNode, Node $targetNode, string $text = '', int $type = self::ARROW, ?string $style = null)
     {
         $this->sourceNode = $sourceNode;
         $this->targetNode = $targetNode;
+        $this->style = $style;
         $this->setText($text);
-        $this->setStyle($style);
+        $this->setType($type);
     }
 
     /**
@@ -80,12 +92,23 @@ class Link
     }
 
     /**
-     * @param int $style
+     * @param int $type
      * @return Link
      */
-    public function setStyle(int $style): Link
+    public function setType(int $type): Link
     {
-        $this->style = $style;
+        $this->type = $type;
+        return $this;
+    }
+
+    /**
+     * The link is assigned an index at render time, which is used in getStyle()
+     * @param int $index
+     * @return Link
+     */
+    public function setIndex(int $index): Link
+    {
+        $this->index = $index;
         return $this;
     }
 
@@ -94,11 +117,22 @@ class Link
      */
     public function __toString()
     {
-        $line = self::TEMPLATES[$this->style][0];
+        $line = self::TEMPLATES[$this->type][0];
         if ($this->text) {
-            $line = sprintf(self::TEMPLATES[$this->style][1], Helper::escape($this->text));
+            $line = sprintf(self::TEMPLATES[$this->type][1], Helper::escape($this->text));
         }
 
         return "{$this->sourceNode->getId()}{$line}{$this->targetNode->getId()};";
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getStyle(): ?string
+    {
+        if (is_null($this->index) || is_null($this->style)) {
+            return null;
+        }
+        return "linkStyle $this->index $this->style";
     }
 }

--- a/tests/FlowchartTest.php
+++ b/tests/FlowchartTest.php
@@ -113,16 +113,16 @@ class FlowchartTest extends PHPUnit
         $link = new Link($nodeA, $nodeB);
 
         isSame('A-->B;', (string)$link);
-        isSame('A-->B;', (string)$link->setStyle(Link::ARROW));
-        isSame('A --- B;', (string)$link->setStyle(Link::LINE));
-        isSame('A ==> B;', (string)$link->setStyle(Link::THICK));
-        isSame('A-.->B;', (string)$link->setStyle(Link::DOTTED));
+        isSame('A-->B;', (string)$link->setType(Link::ARROW));
+        isSame('A --- B;', (string)$link->setType(Link::LINE));
+        isSame('A ==> B;', (string)$link->setType(Link::THICK));
+        isSame('A-.->B;', (string)$link->setType(Link::DOTTED));
 
         $link->setText('This is the text');
-        isSame('A-->|"This is the text"|B;', (string)$link->setStyle(Link::ARROW));
-        isSame('A---|"This is the text"|B;', (string)$link->setStyle(Link::LINE));
-        isSame('A == "This is the text" ==> B;', (string)$link->setStyle(Link::THICK));
-        isSame('A-. "This is the text" .-> B;', (string)$link->setStyle(Link::DOTTED));
+        isSame('A-->|"This is the text"|B;', (string)$link->setType(Link::ARROW));
+        isSame('A---|"This is the text"|B;', (string)$link->setType(Link::LINE));
+        isSame('A == "This is the text" ==> B;', (string)$link->setType(Link::THICK));
+        isSame('A-. "This is the text" .-> B;', (string)$link->setType(Link::DOTTED));
     }
 
     public function testNotFoundNode()


### PR DESCRIPTION
Links can now have individual styles.

The old "style" attribute of Link has been renamed to "type" as in the official documentation https://mermaid-js.github.io/mermaid/#/flowchart?id=links-between-nodes .

The style can be added though a parameter of the constructor.

Example:
```php
$subGraph1
    ->addNode($nodeA = new Node('A', 'AAAA', Node::SQUARE))
    ->addNode($nodeB = new Node('B', 'BBBB', Node::ROUND))
    ->addLink(new Link($nodeA, $nodeB, 'A dec char:♥', Link::ARROW, 'stroke:blue,stroke-width:4px'));
```

Result:

![Screenshot from 2021-07-29 14-58-58](https://user-images.githubusercontent.com/1677625/127496464-78659ba6-ffca-49a2-9885-bdb98569f055.png)
