### PR TITLE
Add class diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JBZoo / Mermaid-PHP
 
-[![CI](https://github.com/JBZoo/Mermaid-PHP/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/JBZoo/Mermaid-PHP/actions/workflows/main.yml?query=branch%3Amaster)    [![Coverage Status](https://coveralls.io/repos/github/JBZoo/Mermaid-PHP/badge.svg?branch=master)](https://coveralls.io/github/JBZoo/Mermaid-PHP?branch=master)    [![Psalm Coverage](https://shepherd.dev/github/JBZoo/Mermaid-PHP/coverage.svg)](https://shepherd.dev/github/JBZoo/Mermaid-PHP)    [![Psalm Level](https://shepherd.dev/github/JBZoo/Mermaid-PHP/level.svg)](https://shepherd.dev/github/JBZoo/Mermaid-PHP)    [![CodeFactor](https://www.codefactor.io/repository/github/jbzoo/mermaid-php/badge)](https://www.codefactor.io/repository/github/jbzoo/mermaid-php/issues)    
+[![CI](https://github.com/JBZoo/Mermaid-PHP/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/JBZoo/Mermaid-PHP/actions/workflows/main.yml?query=branch%3Amaster)    [![Coverage Status](https://coveralls.io/repos/github/JBZoo/Mermaid-PHP/badge.svg?branch=master)](https://coveralls.io/github/JBZoo/Mermaid-PHP?branch=master)    [![Psalm Coverage](https://shepherd.dev/github/JBZoo/Mermaid-PHP/coverage.svg)](https://shepherd.dev/github/JBZoo/Mermaid-PHP)    [![Psalm Level](https://shepherd.dev/github/JBZoo/Mermaid-PHP/level.svg)](https://shepherd.dev/github/JBZoo/Mermaid-PHP)    [![CodeFactor](https://www.codefactor.io/repository/github/jbzoo/mermaid-php/badge)](https://www.codefactor.io/repository/github/jbzoo/mermaid-php/issues)
 [![Stable Version](https://poser.pugx.org/jbzoo/mermaid-php/version)](https://packagist.org/packages/jbzoo/mermaid-php/)    [![Total Downloads](https://poser.pugx.org/jbzoo/mermaid-php/downloads)](https://packagist.org/packages/jbzoo/mermaid-php/stats)    [![Dependents](https://poser.pugx.org/jbzoo/mermaid-php/dependents)](https://packagist.org/packages/jbzoo/mermaid-php/dependents?order_by=downloads)    [![GitHub License](https://img.shields.io/github/license/jbzoo/mermaid-php)](https://github.com/JBZoo/Mermaid-PHP/blob/master/LICENSE)
 
 
@@ -48,7 +48,7 @@ $htmlCode = $graph->renderHtml([
     'mermaid_url' => 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs',
 ]); // Get result as HTML code for debugging
 
-echo $graph->getLiveEditorUrl(); // Get link to live editor 
+echo $graph->getLiveEditorUrl(); // Get link to live editor
 ```
 
 ### Result
@@ -196,6 +196,79 @@ timeline
 
 ```
 
+### Usage of a Class Diagram
+
+```php
+<?php
+
+use JBZoo\MermaidPHP\ClassDiagram\ClassDiagram;
+use JBZoo\MermaidPHP\ClassDiagram\Concept\Concept;
+use JBZoo\MermaidPHP\ClassDiagram\Concept\Attribute;
+use JBZoo\MermaidPHP\ClassDiagram\Concept\Visibility;
+use JBZoo\MermaidPHP\ClassDiagram\Concept\Method;
+use JBZoo\MermaidPHP\ClassDiagram\Relationship\Relationship;
+use JBZoo\MermaidPHP\ClassDiagram\Relationship\RelationType;
+use JBZoo\MermaidPHP\Render;
+
+$diagram = (new ClassDiagram())
+    ->setTitle('Animal example')
+    ->setDirection(\JBZoo\MermaidPHP\Direction::TOP_TO_BOTTOM)
+    ->addClass($animalClass = new Concept(
+        identifier: 'Animal',
+        attributes: [
+            new Attribute('age', 'int', Visibility::PUBLIC),
+            new Attribute('gender', 'String', Visibility::PUBLIC),
+        ],
+        annotation: 'abstract'
+    ))
+    ->addClass($duckClass = new Concept(
+        identifier: 'Duck',
+        attributes: [
+            new Attribute('beakColor', 'String', Visibility::PUBLIC),
+        ],
+        methods: [
+            new Method('swim')
+        ],
+    ))
+    ->addRelationship(new Relationship(
+        classA: $duckClass,
+        classB: $animalClass,
+        relationType: RelationType::REALIZATION
+    ))
+;
+//header('Content-Type: text/plain');
+//echo $diagram; // Get result as string (or $diagram->__toString(), or (string) $diagram)
+$htmlCode = $diagram->renderHtml([
+    'debug'       => true,
+    'theme'       => Render::THEME_DARK,
+    'title'       => 'Example',
+    'show-zoom'   => false,
+    'mermaid_url' => 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs',
+]); // Get result as HTML code for debugging
+
+echo $diagram->getLiveEditorUrl(); // Get link to live editor
+```
+
+### Result
+[Open live editor](https://mermaid-js.github.io/mermaid-live-editor/edit#pako:eNo1kMFugzAMhl8l8mnTEIIS0IoqpG297tSdplzcxGVRSVKFoK1jvPtSCr7E_vz7T-IRpFMENcgO-36vsfVohFXakwzaWfbxKuzcYy9WG-zYKCyLsdvhsQ8eZWiaO3nSNjBsaakOwWvbspasIi_stNrsB3leTVbRkfD85jrn77j_1ubhcZ6Z1Wn61yzXCwsJGPIGtYqvnn0EhC8yJKCO6cl56oOAOB2VOAR3uFoJdfADJTBcFAZavgn1Cbs-0gvaT-fMKool1CP8QJ1znj7zbV5URbkpi21WJXCNOCtTzivO86rMbnQzJfA7O2RpmQApHZx_XxZ7O6Z_kFxzOQ)
+
+```
+---
+title: Animal example
+---
+classDiagram
+direction TB
+class Animal {
+    <<abstract>>
+    +int age
+    +String gender
+}
+class Duck {
+    +String beakColor
+    swim()
+}
+Duck ..|> Animal
+```
 
 ### See also
  - [Mermaid on GitHub](https://github.com/mermaid-js/mermaid)
@@ -221,6 +294,6 @@ MIT
 - [Composer-Graph](https://github.com/JBZoo/Composer-Graph) - Dependency graph visualization of composer.json based on mermaid-js.
 - [Utils](https://github.com/JBZoo/Utils) - Collection of useful PHP functions, mini-classes, and snippets for every day.
 - [Image](https://github.com/JBZoo/Image) - Package provides object-oriented way to manipulate with images as simple as possible.
-- [Data](https://github.com/JBZoo/Data) - Extended implementation of ArrayObject. Use files as config/array. 
+- [Data](https://github.com/JBZoo/Data) - Extended implementation of ArrayObject. Use files as config/array.
 - [Retry](https://github.com/JBZoo/Retry) - Tiny PHP library providing retry/backoff functionality with multiple backoff strategies and jitter support.
 - [SimpleTypes](https://github.com/JBZoo/SimpleTypes) - Converting any values and measures - money, weight, exchange rates, length, ...

--- a/src/ClassDiagram/ClassDiagram.php
+++ b/src/ClassDiagram/ClassDiagram.php
@@ -1,0 +1,132 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Mermaid-PHP.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Mermaid-PHP
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\MermaidPHP\ClassDiagram;
+
+use JBZoo\MermaidPHP\ClassDiagram\Concept\Concept;
+use JBZoo\MermaidPHP\ClassDiagram\ConceptNamespace\ConceptNamespace;
+use JBZoo\MermaidPHP\ClassDiagram\Relationship\Relationship;
+use JBZoo\MermaidPHP\Direction;
+use JBZoo\MermaidPHP\Helper;
+use JBZoo\MermaidPHP\Render;
+
+class ClassDiagram
+{
+    protected ?string $title        = null;
+    protected ?Direction $direction = null;
+
+    /** @var ConceptNamespace[] */
+    protected array $namespaces = [];
+
+    /** @var Concept[] */
+    protected array $classes = [];
+
+    /** @var Relationship[] */
+    protected array $relationships = [];
+
+    public function __toString(): string
+    {
+        return $this->render();
+    }
+
+    public function setTitle(string $title): self
+    {
+        $this->title = $title;
+
+        return $this;
+    }
+
+    public function setDirection(Direction $direction): self
+    {
+        $this->direction = $direction;
+
+        return $this;
+    }
+
+    public function addClass(Concept $class): self
+    {
+        $this->classes[$class->getId()] = $class;
+
+        return $this;
+    }
+
+    public function addNamespace(ConceptNamespace $namespace): self
+    {
+        $this->namespaces[] = $namespace;
+
+        return $this;
+    }
+
+    public function addRelationship(Relationship $relationship): self
+    {
+        $this->relationships[] = $relationship;
+
+        return $this;
+    }
+
+    public function render(): string
+    {
+        $result = [];
+
+        if ($this->title !== null) {
+            $result[] = \sprintf('---%s---', \PHP_EOL . 'title: ' . $this->title . \PHP_EOL);
+        }
+
+        $result[] = 'classDiagram';
+
+        if ($this->direction !== null) {
+            $result[] = \sprintf('direction %s', $this->direction->value);
+        }
+
+        foreach ($this->namespaces as $namespace) {
+            $result[] = $namespace;
+        }
+
+        foreach ($this->classes as $class) {
+            $result[] = $class;
+        }
+
+        foreach ($this->relationships as $relationship) {
+            $result[] = $relationship;
+        }
+
+        $result[] = '';
+
+        return \implode(\PHP_EOL, $result);
+    }
+
+    public function getParams(): array
+    {
+        return \array_filter([
+            'title'     => $this->title,
+            'direction' => $this->direction?->value,
+        ], static fn ($value) => $value !== null);
+    }
+
+    /**
+     * @param  array<string>  $params
+     * @throws \JsonException
+     */
+    public function renderHtml(array $params = []): string
+    {
+        return Render::html($this, $params);
+    }
+
+    public function getLiveEditorUrl(): string
+    {
+        return Helper::getLiveEditorUrl($this);
+    }
+}

--- a/src/ClassDiagram/Concept/Argument.php
+++ b/src/ClassDiagram/Concept/Argument.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Mermaid-PHP.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Mermaid-PHP
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\MermaidPHP\ClassDiagram\Concept;
+
+class Argument implements \Stringable
+{
+    public function __construct(
+        protected string $name,
+        protected ?string $type = null,
+    ) {
+    }
+
+    public function __toString(): string
+    {
+        $output = [];
+
+        if ($this->type !== null) {
+            $output[] = $this->type;
+        }
+
+        $output[] = $this->name;
+
+        return \implode(' ', $output);
+    }
+}

--- a/src/ClassDiagram/Concept/Attribute.php
+++ b/src/ClassDiagram/Concept/Attribute.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Mermaid-PHP.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Mermaid-PHP
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\MermaidPHP\ClassDiagram\Concept;
+
+class Attribute implements \Stringable
+{
+    public function __construct(
+        protected string $name,
+        protected ?string $type = null,
+        protected ?Visibility $visibility = null,
+    ) {
+    }
+
+    public function __toString(): string
+    {
+        $output = [];
+
+        if ($this->type !== null) {
+            $output[] = $this->type;
+        }
+
+        $output[] = $this->name;
+
+        return $this->renderVisibility() . \implode(' ', $output);
+    }
+
+    private function renderVisibility(): string
+    {
+        if ($this->visibility === null) {
+            return '';
+        }
+
+        return $this->visibility->value;
+    }
+}

--- a/src/ClassDiagram/Concept/Concept.php
+++ b/src/ClassDiagram/Concept/Concept.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Mermaid-PHP.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Mermaid-PHP
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\MermaidPHP\ClassDiagram\Concept;
+
+use JBZoo\MermaidPHP\Helper;
+
+class Concept
+{
+    private static bool $safeMode = false;
+    protected string    $identifier;
+
+    /** @var Attribute[] */
+    protected array     $attributes;
+
+    /** @var Method[] */
+    protected array     $methods;
+
+    protected ?string   $annotation;
+
+    /**
+     * @param Attribute[] $attributes
+     * @param Method[]    $methods
+     */
+    public function __construct(
+        string $identifier,
+        array $attributes = [],
+        array $methods = [],
+        ?string $annotation = null,
+    ) {
+        $this->identifier = static::isSafeMode() ? Helper::getId($identifier) : $identifier;
+        $this->attributes = $attributes;
+        $this->methods    = $methods;
+        $this->annotation = $annotation;
+    }
+
+    public function __toString(): string
+    {
+        $result = $this->getLinesToRender();
+
+        return \implode(\PHP_EOL, $result);
+    }
+
+    public function getLinesToRender(): array
+    {
+        $spaces = \str_repeat(' ', 4);
+
+        $result = [];
+
+        $result[] = \sprintf('class %s {', $this->identifier);
+
+        if ($this->annotation !== null) {
+            $result[] = $spaces . \sprintf('<<%s>>', $this->annotation);
+        }
+
+        foreach ($this->attributes as $attribute) {
+            $result[] = $spaces . $attribute;
+        }
+
+        foreach ($this->methods as $method) {
+            $result[] = $spaces . $method;
+        }
+
+        $result[] = '}';
+
+        return $result;
+    }
+
+    public function getId(): string
+    {
+        return $this->identifier;
+    }
+
+    public static function isSafeMode(): bool
+    {
+        return self::$safeMode;
+    }
+}

--- a/src/ClassDiagram/Concept/Method.php
+++ b/src/ClassDiagram/Concept/Method.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Mermaid-PHP.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Mermaid-PHP
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\MermaidPHP\ClassDiagram\Concept;
+
+use JBZoo\MermaidPHP\Exception;
+
+class Method implements \Stringable
+{
+    public function __construct(
+        protected string $name,
+        /** @var Argument[] */
+        protected array $arguments = [],
+        protected ?string $returnType = null,
+        protected ?Visibility $visibility = null,
+        protected bool $isAbstract = false,
+        protected bool $isStatic = false,
+    ) {
+        if ($this->isAbstract && $this->isStatic) {
+            throw new Exception('A method could not be both abstract and static');
+        }
+    }
+
+    public function __toString(): string
+    {
+        $output = [];
+
+        $output[] = \sprintf('%s(%s)', $this->name, \implode(',', $this->arguments));
+
+        if ($this->returnType !== null) {
+            $output[] = $this->returnType;
+        }
+
+        return $this->renderVisibility() . \implode(' ', $output) . $this->renderClassifier();
+    }
+
+    private function renderVisibility(): string
+    {
+        if ($this->visibility === null) {
+            return '';
+        }
+
+        return $this->visibility->value;
+    }
+
+    private function renderClassifier(): string
+    {
+        if ($this->isStatic) {
+            return '$';
+        }
+
+        if ($this->isAbstract) {
+            return '*';
+        }
+
+        return '';
+    }
+}

--- a/src/ClassDiagram/Concept/Visibility.php
+++ b/src/ClassDiagram/Concept/Visibility.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Mermaid-PHP.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Mermaid-PHP
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\MermaidPHP\ClassDiagram\Concept;
+
+enum Visibility: string
+{
+    case PUBLIC              = '+';
+    case PRIVATE             = '-';
+    case PROTECTED           = '#';
+    case PACKAGE_OR_INTERNAL = '~';
+}

--- a/src/ClassDiagram/ConceptNamespace/ConceptNamespace.php
+++ b/src/ClassDiagram/ConceptNamespace/ConceptNamespace.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Mermaid-PHP.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Mermaid-PHP
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\MermaidPHP\ClassDiagram\ConceptNamespace;
+
+use JBZoo\MermaidPHP\ClassDiagram\Concept\Concept;
+
+class ConceptNamespace
+{
+    public function __construct(
+        protected string $identifier,
+        /** @var Concept[] */
+        protected array $classes,
+    ) {
+    }
+
+    public function __toString(): string
+    {
+        $spaces = \str_repeat(' ', 4);
+
+        $result = [];
+
+        $result[] = \sprintf('namespace %s {', $this->identifier);
+
+        /** @var Concept $class */
+        foreach ($this->classes as $class) {
+            foreach ($class->getLinesToRender() as $line) {
+                $result[] = $spaces . $line;
+            }
+        }
+
+        $result[] = '}';
+
+        return \implode(\PHP_EOL, $result);
+    }
+}

--- a/src/ClassDiagram/Relationship/Cardinality.php
+++ b/src/ClassDiagram/Relationship/Cardinality.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Mermaid-PHP.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Mermaid-PHP
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\MermaidPHP\ClassDiagram\Relationship;
+
+enum Cardinality: string
+{
+    case ONE         = '1';
+    case ZERO_OR_ONE = '0..1';
+    case ONE_OR_MORE = '1..*';
+    case MANY        = '*';
+    case N           = 'n';
+    case ZERO_TO_N   = '0..n';
+    case ONE_TO_N    = '1..n';
+}

--- a/src/ClassDiagram/Relationship/Link.php
+++ b/src/ClassDiagram/Relationship/Link.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Mermaid-PHP.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Mermaid-PHP
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\MermaidPHP\ClassDiagram\Relationship;
+
+enum Link: string
+{
+    case SOLID  = '--';
+    case DASHED = '..';
+}

--- a/src/ClassDiagram/Relationship/RelationType.php
+++ b/src/ClassDiagram/Relationship/RelationType.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Mermaid-PHP.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Mermaid-PHP
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\MermaidPHP\ClassDiagram\Relationship;
+
+enum RelationType
+{
+    case INHERITANCE;
+    case COMPOSITION;
+    case AGGREGATION;
+    case ASSOCIATION;
+    case DEPENDENCY;
+    case REALIZATION;
+    // not documented
+    case LOLLILOP;
+
+    public function getDefaultLink(): Link
+    {
+        return match ($this) {
+            self::DEPENDENCY, self::REALIZATION => Link::DASHED,
+            default => Link::SOLID,
+        };
+    }
+
+    public function renderRelation(Link $link, ?RelationType $inverse): string
+    {
+        return match ($this) {
+            self::AGGREGATION, self::COMPOSITION => $this->renderDirect() . $link->value . $inverse?->renderInverse(),
+            default => $inverse?->renderInverse() . $link->value . $this->renderDirect(),
+        };
+    }
+
+    private function renderDirect(): string
+    {
+        return match ($this) {
+            self::INHERITANCE, self::REALIZATION => '|>',
+            self::COMPOSITION => '*',
+            self::AGGREGATION => 'o',
+            self::ASSOCIATION, self::DEPENDENCY => '>',
+            self::LOLLILOP => '(),'
+        };
+    }
+
+    private function renderInverse(): string
+    {
+        return match ($this) {
+            self::INHERITANCE, self::REALIZATION => '<|',
+            self::ASSOCIATION, self::DEPENDENCY => '<',
+            default => $this->renderDirect(),
+        };
+    }
+}

--- a/src/ClassDiagram/Relationship/Relationship.php
+++ b/src/ClassDiagram/Relationship/Relationship.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Mermaid-PHP.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Mermaid-PHP
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\MermaidPHP\ClassDiagram\Relationship;
+
+use JBZoo\MermaidPHP\ClassDiagram\Concept\Concept;
+
+class Relationship
+{
+    public function __construct(
+        protected Concept $classA,
+        protected Concept $classB,
+        protected RelationType $relationType,
+        protected ?string $label = null,
+        protected null|Cardinality|string $cardinalityA = null,
+        protected null|Cardinality|string $cardinalityB = null,
+        protected ?Link $link = null,
+        protected ?RelationType $inverseRelationType = null,
+    ) {
+        if ($this->link === null) {
+            $this->link = $this->relationType->getDefaultLink();
+        }
+    }
+
+    public function __toString(): string
+    {
+        $result = \sprintf(
+            '%s%s %s%s %s',
+            $this->classA->getId(),
+            self::renderCardinality($this->cardinalityA),
+            $this->renderRelation(),
+            self::renderCardinality($this->cardinalityB),
+            $this->classB->getId(),
+        );
+
+        if ($this->label !== null) {
+            $result .= \sprintf(' : %s', $this->label);
+        }
+
+        return $result;
+    }
+
+    private function renderRelation(): string
+    {
+        return $this->relationType->renderRelation($this->link, $this->inverseRelationType);
+    }
+
+    private static function renderCardinality(null|Cardinality|string $cardinality): string
+    {
+        if ($cardinality === null) {
+            return '';
+        }
+
+        $value = $cardinality instanceof Cardinality ? $cardinality->value : $cardinality;
+
+        return \sprintf(' "%s"', $value);
+    }
+}

--- a/src/Direction.php
+++ b/src/Direction.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Mermaid-PHP.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Mermaid-PHP
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\MermaidPHP;
+
+enum Direction: string
+{
+    case TOP_TO_BOTTOM = 'TB';
+    case BOTTOM_TO_TOP = 'BT';
+    case LEFT_TO_RIGHT = 'LR';
+    case RIGHT_TO_LEFT = 'RL';
+}

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\MermaidPHP;
 
+use JBZoo\MermaidPHP\ClassDiagram\ClassDiagram;
 use JBZoo\MermaidPHP\ERDiagram\ERDiagram;
 use JBZoo\MermaidPHP\Timeline\Timeline;
 
@@ -35,7 +36,7 @@ class Helper
         return \md5($userFriendlyId);
     }
 
-    public static function getLiveEditorUrl(ERDiagram|Graph|Timeline $mermaid): string
+    public static function getLiveEditorUrl(ClassDiagram|ERDiagram|Graph|Timeline $mermaid): string
     {
         $json = \json_encode([
             'code'    => (string)$mermaid,

--- a/src/Render.php
+++ b/src/Render.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\MermaidPHP;
 
+use JBZoo\MermaidPHP\ClassDiagram\ClassDiagram;
 use JBZoo\MermaidPHP\ERDiagram\ERDiagram;
 use JBZoo\MermaidPHP\Timeline\Timeline;
 
@@ -28,7 +29,7 @@ class Render
 
     public const DEFAULT_MERMAID_URL = 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';
 
-    public static function html(ERDiagram|Graph|Timeline $graph, array $params = []): string
+    public static function html(ClassDiagram|ERDiagram|Graph|Timeline $graph, array $params = []): string
     {
         $theme     = (string)($params['theme'] ?? self::THEME_FOREST);
         $scriptUrl = (string)($params['mermaid_url'] ?? self::DEFAULT_MERMAID_URL);

--- a/tests/ClassDiagramTest.php
+++ b/tests/ClassDiagramTest.php
@@ -1,0 +1,202 @@
+<?php
+
+/**
+ * JBZoo Toolbox - Mermaid-PHP.
+ *
+ * This file is part of the JBZoo Toolbox project.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT
+ * @copyright  Copyright (C) JBZoo.com, All rights reserved.
+ * @see        https://github.com/JBZoo/Mermaid-PHP
+ */
+
+declare(strict_types=1);
+
+namespace JBZoo\PHPUnit;
+
+use JBZoo\MermaidPHP\ClassDiagram\ClassDiagram;
+use JBZoo\MermaidPHP\ClassDiagram\Concept\Argument;
+use JBZoo\MermaidPHP\ClassDiagram\Concept\Attribute;
+use JBZoo\MermaidPHP\ClassDiagram\Concept\Concept;
+use JBZoo\MermaidPHP\ClassDiagram\Concept\Method;
+use JBZoo\MermaidPHP\ClassDiagram\Concept\Visibility;
+use JBZoo\MermaidPHP\ClassDiagram\ConceptNamespace\ConceptNamespace;
+use JBZoo\MermaidPHP\ClassDiagram\Relationship\Cardinality;
+use JBZoo\MermaidPHP\ClassDiagram\Relationship\Relationship;
+use JBZoo\MermaidPHP\ClassDiagram\Relationship\RelationType;
+use JBZoo\MermaidPHP\Direction;
+
+class ClassDiagramTest extends PHPUnit
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    public function testBasicClassDiagram(): void
+    {
+        $diagram = new ClassDiagram();
+        $diagram->addClass(new Concept('A', [], [], 'interface'));
+        $diagram->addClass(
+            class: new Concept(
+                'BankAccount',
+                attributes: [
+                    new Attribute('owner', 'String'),
+                    new Attribute('balance', 'BigDecimal', Visibility::PUBLIC),
+                ],
+                methods: [
+                    new Method(
+                        name: 'deposit',
+                        arguments: [new Argument('amount', 'int')],
+                        returnType: 'bool',
+                        isStatic: true,
+                    ),
+                    new Method(
+                        name: 'withdrawal',
+                        arguments: [new Argument('amount')],
+                        visibility: Visibility::PUBLIC,
+                        isAbstract: true,
+                    ),
+                ],
+            ),
+        );
+
+        is(\implode(\PHP_EOL, [
+            'classDiagram',
+            'class A {',
+            '    <<interface>>',
+            '}',
+            'class BankAccount {',
+            '    String owner',
+            '    +BigDecimal balance',
+            '    deposit(int amount) bool$',
+            '    +withdrawal(amount)*',
+            '}',
+            '',
+        ]), (string)$diagram);
+    }
+
+    public function testDiagramWithTitle(): void
+    {
+        $diagram = new ClassDiagram();
+        $diagram->setTitle('Animal example');
+
+        is(\implode(\PHP_EOL, [
+            '---',
+            'title: Animal example',
+            '---',
+            'classDiagram',
+            '',
+        ]), (string)$diagram);
+    }
+
+    public function testDiagramWithDirection(): void
+    {
+        $diagram = new ClassDiagram();
+        $diagram->setDirection(Direction::BOTTOM_TO_TOP);
+
+        is(\implode(\PHP_EOL, [
+            'classDiagram',
+            'direction BT',
+            '',
+        ]), (string)$diagram);
+    }
+
+    public function testClassWithNoMembers(): void
+    {
+        $class = new Concept('A');
+
+        is(\implode(\PHP_EOL, [
+            'class A {',
+            '}',
+        ]), (string)$class);
+    }
+
+    public function testClassWithAttributes(): void
+    {
+        $class = new Concept('Animal', [
+            new Attribute('age', 'int', Visibility::PUBLIC),
+            new Attribute('gender', 'String', Visibility::PRIVATE),
+        ]);
+
+        is(\implode(\PHP_EOL, [
+            'class Animal {',
+            '    +int age',
+            '    -String gender',
+            '}',
+        ]), (string)$class);
+    }
+
+    public function testRelationship(): void
+    {
+        $relationship = new Relationship(
+            classA: new Concept('A'),
+            classB: new Concept('B'),
+            relationType: RelationType::INHERITANCE,
+        );
+
+        is('A --|> B', (string)$relationship);
+    }
+
+    public function testRelationshipWithLabel(): void
+    {
+        $relationship = new Relationship(
+            classA: new Concept('A'),
+            classB: new Concept('B'),
+            relationType: RelationType::COMPOSITION,
+            label: 'composition',
+        );
+
+        is('A *-- B : composition', (string)$relationship);
+    }
+
+    public function testRelationshipWithCardinality(): void
+    {
+        $relationship = new Relationship(
+            classA: new Concept('A'),
+            classB: new Concept('B'),
+            relationType: RelationType::AGGREGATION,
+            label: 'composition',
+            cardinalityA: Cardinality::ONE,
+            cardinalityB: 'many',
+        );
+
+        is('A "1" o-- "many" B : composition', (string)$relationship);
+    }
+
+    public function testRelationshipWithInverse(): void
+    {
+        $relationship = new Relationship(
+            classA: new Concept('A'),
+            classB: new Concept('B'),
+            relationType: RelationType::AGGREGATION,
+            inverseRelationType: RelationType::AGGREGATION,
+        );
+
+        is('A o--o B', (string)$relationship);
+    }
+
+    public function testNamespace(): void
+    {
+        $namespace = new ConceptNamespace('BaseShapes', [
+            new Concept('Triangle'),
+            new Concept('Rectangle', [
+                new Attribute('width', 'double'),
+                new Attribute('height', 'double'),
+            ]),
+        ]);
+
+        is(\implode(\PHP_EOL, [
+            'namespace BaseShapes {',
+            '    class Triangle {',
+            '    }',
+            '    class Rectangle {',
+            '        double width',
+            '        double height',
+            '    }',
+            '}',
+        ]), (string)$namespace);
+    }
+}


### PR DESCRIPTION
Hi, this PR is a draft to add support for the class diagram, documented here: https://mermaid.js.org/syntax/classDiagram.html

The implementation was more difficult than I initially thought, and there are some solutions that could probably be improved.

Some aspects I would like to have feedback on:
- The words `Class` and `Namespace` cannot be used (as class name or part of namespace) because they are reserved. I've been using `Concept` and `ConceptNamespace` at the moment, but I'd definitely like to find better alternatives. Any suggestions?
- I believe the relationships that can be defined with Mermaid go beyond those allowed by UML, in particular for bidirectional relationships. I hope I have found the right balance between ease in defining the most common relationships and the possibility of exploiting everything that can be done with Mermaid. However, I still have at least one doubt, for `aggregation` and `composition` relationship from `A` to `B` I decided to position the relevant symbol close to class `A`, while for the other relationships the arrow (open or closed) points to the class `B`, because it makes sense to me based on my little knowledge of UML, but I might be missing something.