### PR TITLE
[Fix] mermaid is not defined

### DIFF
--- a/src/Render.php
+++ b/src/Render.php
@@ -79,6 +79,8 @@ class Render
             '   <script src="https://code.jquery.com/jquery-3.4.1.slim.min.js"></script>',
             '<script type="module">',
             "        import mermaid from '{$scriptUrl}';",
+            "        window.mermaid = mermaid;",
+            "        document.dispatchEvent(new Event('MermaidLoaded'));",
             '</script>',
             '</head>',
             '<body>',
@@ -92,13 +94,13 @@ class Render
             $showZoom ?
                 "<input type=\"button\" class=\"btn btn-primary\" id=\"zoom\" value=\"Zoom In\">
                 <script>
-                     mermaid.initialize({$mermaidParams});
-                     $(function () {
+                    document.addEventListener('MermaidLoaded', fn () => mermaid.initialize({$mermaidParams}));
+                    $(function () {
                         $('#zoom').click(() => {
                             $('.mermaid').removeAttr('data-processed');
                             $('.mermaid').width($('.mermaid svg').css('max-width'));
                         });
-                     });
+                    });
                 </script>"
                 : '',
             '<script>


### PR DESCRIPTION
Currently when using Composer-Graph by following it's readme i do receive the following error message:
`Uncaught ReferenceError: mermaid is not defined`

This is due to multiple reasons:
- Mermaid is loaded using ESM `import` which is an asynchronous operation
  > Scripts without [async](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#async), [defer] 
 (https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#defer) or type="module" attributes, as well as inline scripts 
  without the type="module" attribute, are fetched and executed immediately before the browser continues to parse the page.  

  See: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#notes 
- The `mermaid` identifier is only available in the script block it has been imported in
- `mermaid.initialize()` is called before mermaid is either loaded or available

This pull request will solve this issue with Mermaid-PHP and Composer-Graph by binding mermaid to the global scope (window), emit a event and initialize only after said event has been emitted.