### PR TITLE
build: Bump PHP to 8.2 and update dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,8 @@
 #
 
 name: CI
+permissions:
+  contents: read
 
 on:
   pull_request:
@@ -19,8 +21,6 @@ on:
   push:
     branches:
       - 'master'
-  schedule:
-    - cron: '22 */8 * * *'
 
 env:
   COLUMNS: 120
@@ -34,7 +34,7 @@ jobs:
       JBZOO_COMPOSER_UPDATE_FLAGS: ${{ matrix.composer_flags }}
     strategy:
       matrix:
-        php-version: [ 8.1, 8.2, 8.3 ]
+        php-version: [ 8.2, 8.3, 8.4 ]
         coverage: [ xdebug , none]
         composer_flags: [ "--prefer-lowest", "" ]
     steps:
@@ -65,7 +65,7 @@ jobs:
         run: make report-coveralls --no-print-directory || true
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         continue-on-error: true
         with:
           name: PHPUnit - ${{ matrix.php-version }} - ${{ matrix.coverage }}
@@ -77,7 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [ 8.1, 8.2, 8.3 ]
+        php-version: [ 8.2, 8.3, 8.4 ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -99,7 +99,7 @@ jobs:
         run: make codestyle --no-print-directory
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         continue-on-error: true
         with:
           name: Linters - ${{ matrix.php-version }}
@@ -111,7 +111,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [ 8.1, 8.2, 8.3 ]
+        php-version: [ 8.2, 8.3, 8.4 ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -133,7 +133,7 @@ jobs:
         run: make report-all --no-print-directory
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         continue-on-error: true
         with:
           name: Reports - ${{ matrix.php-version }}

--- a/README.md
+++ b/README.md
@@ -1,9 +1,15 @@
 # JBZoo / Mermaid-PHP
 
-[![CI](https://github.com/JBZoo/Mermaid-PHP/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/JBZoo/Mermaid-PHP/actions/workflows/main.yml?query=branch%3Amaster)    [![Coverage Status](https://coveralls.io/repos/github/JBZoo/Mermaid-PHP/badge.svg?branch=master)](https://coveralls.io/github/JBZoo/Mermaid-PHP?branch=master)    [![Psalm Coverage](https://shepherd.dev/github/JBZoo/Mermaid-PHP/coverage.svg)](https://shepherd.dev/github/JBZoo/Mermaid-PHP)    [![Psalm Level](https://shepherd.dev/github/JBZoo/Mermaid-PHP/level.svg)](https://shepherd.dev/github/JBZoo/Mermaid-PHP)    [![CodeFactor](https://www.codefactor.io/repository/github/jbzoo/mermaid-php/badge)](https://www.codefactor.io/repository/github/jbzoo/mermaid-php/issues)    
-[![Stable Version](https://poser.pugx.org/jbzoo/mermaid-php/version)](https://packagist.org/packages/jbzoo/mermaid-php/)    [![Total Downloads](https://poser.pugx.org/jbzoo/mermaid-php/downloads)](https://packagist.org/packages/jbzoo/mermaid-php/stats)    [![Dependents](https://poser.pugx.org/jbzoo/mermaid-php/dependents)](https://packagist.org/packages/jbzoo/mermaid-php/dependents?order_by=downloads)    [![GitHub License](https://img.shields.io/github/license/jbzoo/mermaid-php)](https://github.com/JBZoo/Mermaid-PHP/blob/master/LICENSE)
+[![CI](https://github.com/JBZoo/Mermaid-PHP/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/JBZoo/Mermaid-PHP/actions/workflows/main.yml?query=branch%3Amaster)
+[![Coverage Status](https://coveralls.io/repos/github/JBZoo/Mermaid-PHP/badge.svg?branch=master)](https://coveralls.io/github/JBZoo/Mermaid-PHP?branch=master)
+[![Psalm Coverage](https://shepherd.dev/github/JBZoo/Mermaid-PHP/coverage.svg)](https://shepherd.dev/github/JBZoo/Mermaid-PHP)
+[![Psalm Level](https://shepherd.dev/github/JBZoo/Mermaid-PHP/level.svg)](https://shepherd.dev/github/JBZoo/Mermaid-PHP)
+[![CodeFactor](https://www.codefactor.io/repository/github/jbzoo/mermaid-php/badge)](https://www.codefactor.io/repository/github/jbzoo/mermaid-php/issues)
 
-
+[![Stable Version](https://poser.pugx.org/jbzoo/mermaid-php/version)](https://packagist.org/packages/jbzoo/mermaid-php/)
+[![Total Downloads](https://poser.pugx.org/jbzoo/mermaid-php/downloads)](https://packagist.org/packages/jbzoo/mermaid-php/stats)
+[![Dependents](https://poser.pugx.org/jbzoo/mermaid-php/dependents)](https://packagist.org/packages/jbzoo/mermaid-php/dependents?order_by=downloads)
+[![GitHub License](https://img.shields.io/github/license/jbzoo/mermaid-php)](https://github.com/JBZoo/Mermaid-PHP/blob/master/LICENSE)
 
 Generate diagrams and flowcharts as HTML which is based on [mermaid-js](https://mermaid.js.org/).
 

--- a/composer.json
+++ b/composer.json
@@ -21,12 +21,12 @@
     "prefer-stable"     : true,
 
     "require"           : {
-        "php"      : "^8.1",
+        "php"      : "^8.2",
         "ext-json" : "*"
     },
 
     "require-dev"       : {
-        "jbzoo/toolbox-dev" : "^7.1"
+        "jbzoo/toolbox-dev" : "^7.3"
     },
 
     "autoload"          : {

--- a/src/ClassDiagram/ClassDiagram.php
+++ b/src/ClassDiagram/ClassDiagram.php
@@ -23,19 +23,19 @@ use JBZoo\MermaidPHP\Direction;
 use JBZoo\MermaidPHP\Helper;
 use JBZoo\MermaidPHP\Render;
 
-class ClassDiagram
+final class ClassDiagram
 {
-    protected ?string $title        = null;
-    protected ?Direction $direction = null;
+    private ?string $title        = null;
+    private ?Direction $direction = null;
 
     /** @var ConceptNamespace[] */
-    protected array $namespaces = [];
+    private array $namespaces = [];
 
     /** @var Concept[] */
-    protected array $classes = [];
+    private array $classes = [];
 
     /** @var Relationship[] */
-    protected array $relationships = [];
+    private array $relationships = [];
 
     public function __toString(): string
     {

--- a/src/ClassDiagram/Concept/Argument.php
+++ b/src/ClassDiagram/Concept/Argument.php
@@ -16,11 +16,11 @@ declare(strict_types=1);
 
 namespace JBZoo\MermaidPHP\ClassDiagram\Concept;
 
-class Argument implements \Stringable
+final class Argument implements \Stringable
 {
     public function __construct(
-        protected string $name,
-        protected ?string $type = null,
+        private string $name,
+        private ?string $type = null,
     ) {
     }
 

--- a/src/ClassDiagram/Concept/Attribute.php
+++ b/src/ClassDiagram/Concept/Attribute.php
@@ -16,12 +16,12 @@ declare(strict_types=1);
 
 namespace JBZoo\MermaidPHP\ClassDiagram\Concept;
 
-class Attribute implements \Stringable
+final class Attribute implements \Stringable
 {
     public function __construct(
-        protected string $name,
-        protected ?string $type = null,
-        protected ?Visibility $visibility = null,
+        private string $name,
+        private ?string $type = null,
+        private ?Visibility $visibility = null,
     ) {
     }
 

--- a/src/ClassDiagram/Concept/Concept.php
+++ b/src/ClassDiagram/Concept/Concept.php
@@ -18,18 +18,18 @@ namespace JBZoo\MermaidPHP\ClassDiagram\Concept;
 
 use JBZoo\MermaidPHP\Helper;
 
-class Concept
+final class Concept
 {
     private static bool $safeMode = false;
-    protected string    $identifier;
+    private string    $identifier;
 
     /** @var Attribute[] */
-    protected array     $attributes;
+    private array     $attributes;
 
     /** @var Method[] */
-    protected array     $methods;
+    private array     $methods;
 
-    protected ?string   $annotation;
+    private ?string   $annotation;
 
     /**
      * @param Attribute[] $attributes
@@ -41,7 +41,7 @@ class Concept
         array $methods = [],
         ?string $annotation = null,
     ) {
-        $this->identifier = static::isSafeMode() ? Helper::getId($identifier) : $identifier;
+        $this->identifier = self::isSafeMode() ? Helper::getId($identifier) : $identifier;
         $this->attributes = $attributes;
         $this->methods    = $methods;
         $this->annotation = $annotation;
@@ -67,11 +67,11 @@ class Concept
         }
 
         foreach ($this->attributes as $attribute) {
-            $result[] = $spaces . $attribute;
+            $result[] = $spaces . $attribute->__toString();
         }
 
         foreach ($this->methods as $method) {
-            $result[] = $spaces . $method;
+            $result[] = $spaces . $method->__toString();
         }
 
         $result[] = '}';

--- a/src/ClassDiagram/Concept/Method.php
+++ b/src/ClassDiagram/Concept/Method.php
@@ -18,16 +18,16 @@ namespace JBZoo\MermaidPHP\ClassDiagram\Concept;
 
 use JBZoo\MermaidPHP\Exception;
 
-class Method implements \Stringable
+final class Method implements \Stringable
 {
     public function __construct(
-        protected string $name,
+        private string $name,
         /** @var Argument[] */
-        protected array $arguments = [],
-        protected ?string $returnType = null,
-        protected ?Visibility $visibility = null,
-        protected bool $isAbstract = false,
-        protected bool $isStatic = false,
+        private array $arguments = [],
+        private ?string $returnType = null,
+        private ?Visibility $visibility = null,
+        private bool $isAbstract = false,
+        private bool $isStatic = false,
     ) {
         if ($this->isAbstract && $this->isStatic) {
             throw new Exception('A method could not be both abstract and static');

--- a/src/ClassDiagram/ConceptNamespace/ConceptNamespace.php
+++ b/src/ClassDiagram/ConceptNamespace/ConceptNamespace.php
@@ -18,13 +18,13 @@ namespace JBZoo\MermaidPHP\ClassDiagram\ConceptNamespace;
 
 use JBZoo\MermaidPHP\ClassDiagram\Concept\Concept;
 
-class ConceptNamespace
+final class ConceptNamespace
 {
-    public function __construct(
-        protected string $identifier,
-        /** @var Concept[] */
-        protected array $classes,
-    ) {
+    /**
+     * @param Concept[] $classes
+     */
+    public function __construct(private string $identifier, private array $classes)
+    {
     }
 
     public function __toString(): string
@@ -35,7 +35,6 @@ class ConceptNamespace
 
         $result[] = \sprintf('namespace %s {', $this->identifier);
 
-        /** @var Concept $class */
         foreach ($this->classes as $class) {
             foreach ($class->getLinesToRender() as $line) {
                 $result[] = $spaces . $line;

--- a/src/ClassDiagram/Relationship/Relationship.php
+++ b/src/ClassDiagram/Relationship/Relationship.php
@@ -18,17 +18,17 @@ namespace JBZoo\MermaidPHP\ClassDiagram\Relationship;
 
 use JBZoo\MermaidPHP\ClassDiagram\Concept\Concept;
 
-class Relationship
+final class Relationship
 {
     public function __construct(
-        protected Concept $classA,
-        protected Concept $classB,
-        protected RelationType $relationType,
-        protected ?string $label = null,
-        protected null|Cardinality|string $cardinalityA = null,
-        protected null|Cardinality|string $cardinalityB = null,
-        protected ?Link $link = null,
-        protected ?RelationType $inverseRelationType = null,
+        private Concept $classA,
+        private Concept $classB,
+        private RelationType $relationType,
+        private ?string $label = null,
+        private Cardinality|string|null $cardinalityA = null,
+        private Cardinality|string|null $cardinalityB = null,
+        private ?Link $link = null,
+        private ?RelationType $inverseRelationType = null,
     ) {
         if ($this->link === null) {
             $this->link = $this->relationType->getDefaultLink();
@@ -62,7 +62,7 @@ class Relationship
         return $this->relationType->renderRelation($this->link, $this->inverseRelationType);
     }
 
-    private static function renderCardinality(null|Cardinality|string $cardinality): string
+    private static function renderCardinality(Cardinality|string|null $cardinality): string
     {
         if ($cardinality === null) {
             return '';

--- a/src/ERDiagram/ERDiagram.php
+++ b/src/ERDiagram/ERDiagram.php
@@ -21,18 +21,18 @@ use JBZoo\MermaidPHP\ERDiagram\Relation\Relation;
 use JBZoo\MermaidPHP\Helper;
 use JBZoo\MermaidPHP\Render;
 
-class ERDiagram
+final class ERDiagram
 {
     private const RENDER_SHIFT = 4;
 
     /** @var Entity[] */
-    protected array $entities = [];
+    private array $entities = [];
 
     /** @var Relation[] */
-    protected array $relations = [];
+    private array $relations = [];
 
     /** @var mixed[] */
-    protected array $params = [
+    private array $params = [
         'abc_order' => false,
         'title'     => '',
     ];
@@ -97,7 +97,7 @@ class ERDiagram
             $tmp = [];
 
             foreach ($this->relations as $relation) {
-                $tmp[] = $spacesSub . $relation;
+                $tmp[] = $spacesSub . $relation->__toString();
             }
 
             if ($this->params['abc_order'] === true) {

--- a/src/ERDiagram/Entity/Entity.php
+++ b/src/ERDiagram/Entity/Entity.php
@@ -18,21 +18,21 @@ namespace JBZoo\MermaidPHP\ERDiagram\Entity;
 
 use JBZoo\MermaidPHP\Helper;
 
-class Entity
+final class Entity
 {
-    private static bool $safeMode   = false;
-    protected string    $identifier = '';
-    protected string    $title      = '';
+    private static bool $safeMode = false;
+    private string    $identifier = '';
+    private string    $title      = '';
 
     /** @var EntityProperty[] */
-    protected array      $props = [];
+    private array      $props = [];
 
     /**
      * @param EntityProperty[] $props
      */
     public function __construct(string $identifier, string $title = '', array $props = [])
     {
-        $this->identifier = static::isSafeMode() ? Helper::getId($identifier) : $identifier;
+        $this->identifier = self::isSafeMode() ? Helper::getId($identifier) : $identifier;
         $this->setTitle($title === '' ? $identifier : $title);
         $this->setProps($props);
     }
@@ -80,11 +80,10 @@ class Entity
 
         $props = $this->getProps();
         if ($props !== []) {
-            $output = $this . ' {' . \PHP_EOL;
+            $output = $this->__toString() . ' {' . \PHP_EOL;
 
             foreach ($props as $prop) {
-                /** @var EntityProperty $prop */
-                $output .= $spaces . $spaces . $prop . \PHP_EOL;
+                $output .= $spaces . $spaces . $prop->__toString() . \PHP_EOL;
             }
 
             return $output . $spaces . '}';

--- a/src/ERDiagram/Entity/EntityProperty.php
+++ b/src/ERDiagram/Entity/EntityProperty.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\MermaidPHP\ERDiagram\Entity;
 
-class EntityProperty implements \Stringable
+final class EntityProperty implements \Stringable
 {
     public const PRIMARY_KEY = 'PK';
     public const FOREIGN_KEY = 'FK';
@@ -26,10 +26,10 @@ class EntityProperty implements \Stringable
      * @param string[] $keys
      */
     public function __construct(
-        protected string $name,
-        protected string $type,
-        protected array $keys = [],
-        protected string $comment = '',
+        private string $name,
+        private string $type,
+        private array $keys = [],
+        private string $comment = '',
     ) {
     }
 

--- a/src/ERDiagram/Relation/ManyToMany.php
+++ b/src/ERDiagram/Relation/ManyToMany.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\MermaidPHP\ERDiagram\Relation;
 
-class ManyToMany extends Relation
+final class ManyToMany extends Relation
 {
     public function getLink(): string
     {

--- a/src/ERDiagram/Relation/ManyToOne.php
+++ b/src/ERDiagram/Relation/ManyToOne.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\MermaidPHP\ERDiagram\Relation;
 
-class ManyToOne extends Relation
+final class ManyToOne extends Relation
 {
     public function getLink(): string
     {

--- a/src/ERDiagram/Relation/OneToMany.php
+++ b/src/ERDiagram/Relation/OneToMany.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\MermaidPHP\ERDiagram\Relation;
 
-class OneToMany extends Relation
+final class OneToMany extends Relation
 {
     public function getLink(): string
     {

--- a/src/ERDiagram/Relation/OneToOne.php
+++ b/src/ERDiagram/Relation/OneToOne.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\MermaidPHP\ERDiagram\Relation;
 
-class OneToOne extends Relation
+final class OneToOne extends Relation
 {
     public function getLink(): string
     {

--- a/src/ERDiagram/Relation/Relation.php
+++ b/src/ERDiagram/Relation/Relation.php
@@ -26,22 +26,27 @@ abstract class Relation
     public const ONE_OR_MORE  = '+';
 
     protected static bool $safeMode = false;
-    protected Entity    $firstEntity;
-    protected Entity    $secondEntity;
-    protected string    $identifier   = '';
-    protected ?string    $action      = '';
-    protected ?string    $cardinality = null;
-    protected bool      $identifying  = true;
+    protected Entity      $firstEntity;
+    protected Entity      $secondEntity;
+    protected string      $identifier  = '';
+    protected ?string     $action      = '';
+    protected ?string     $cardinality = null;
+    protected bool        $identifying = true;
 
     abstract public function getLink(): string;
 
     /**
      * @codingStandardsIgnoreStart
      */
-    public function __construct(Entity $firstEntity, Entity $secondEntity, ?string $action = null, ?string $cardinality = null, bool $identifying = true)
-    {
-        /** @codingStandardsIgnoreEnd  */
-        $identifier         = $firstEntity . $secondEntity;
+    public function __construct(
+        Entity $firstEntity,
+        Entity $secondEntity,
+        ?string $action = null,
+        ?string $cardinality = null,
+        bool $identifying = true,
+    ) {
+        /** @codingStandardsIgnoreEnd */
+        $identifier         = $firstEntity->__toString() . $secondEntity->__toString();
         $this->identifier   = static::isSafeMode() ? Helper::getId($identifier) : $identifier;
         $this->firstEntity  = $firstEntity;
         $this->secondEntity = $secondEntity;

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -16,6 +16,6 @@ declare(strict_types=1);
 
 namespace JBZoo\MermaidPHP;
 
-class Exception extends \RuntimeException
+final class Exception extends \RuntimeException
 {
 }

--- a/src/Graph.php
+++ b/src/Graph.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\MermaidPHP;
 
-class Graph
+final class Graph
 {
     public const TOP_BOTTOM = 'TB';
     public const BOTTOM_TOP = 'BT';
@@ -26,23 +26,23 @@ class Graph
     private const RENDER_SHIFT = 4;
 
     /** @var Graph[] */
-    protected array $subGraphs = [];
+    private array $subGraphs = [];
 
     /** @var Node[] */
-    protected array $nodes = [];
+    private array $nodes = [];
 
     /** @var Link[] */
-    protected array $links = [];
+    private array $links = [];
 
     /** @var mixed[] */
-    protected array $params = [
+    private array $params = [
         'abc_order' => false,
         'title'     => 'Graph',
         'direction' => self::TOP_BOTTOM,
     ];
 
     /** @var string[] */
-    protected $styles = [];
+    private $styles = [];
 
     /**
      * @param mixed[] $params
@@ -76,7 +76,7 @@ class Graph
             $tmp = [];
 
             foreach ($this->nodes as $node) {
-                $tmp[] = $spacesSub . $node;
+                $tmp[] = $spacesSub . $node->__toString();
             }
 
             if ($this->params['abc_order'] === true) {
@@ -93,7 +93,7 @@ class Graph
             $tmp = [];
 
             foreach ($this->links as $link) {
-                $tmp[] = $spacesSub . $link;
+                $tmp[] = $spacesSub . $link->__toString();
             }
 
             if ($this->params['abc_order'] === true) {

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -20,7 +20,7 @@ use JBZoo\MermaidPHP\ClassDiagram\ClassDiagram;
 use JBZoo\MermaidPHP\ERDiagram\ERDiagram;
 use JBZoo\MermaidPHP\Timeline\Timeline;
 
-class Helper
+final class Helper
 {
     public static function escape(string $text): string
     {

--- a/src/Link.php
+++ b/src/Link.php
@@ -16,24 +16,24 @@ declare(strict_types=1);
 
 namespace JBZoo\MermaidPHP;
 
-class Link
+final class Link
 {
     public const ARROW  = 1;
     public const LINE   = 2;
     public const DOTTED = 3;
     public const THICK  = 4;
 
-    protected const TEMPLATES = [
+    private const TEMPLATES = [
         self::ARROW  => ['-->', '-->|%s|'],
         self::LINE   => [' --- ', '---|%s|'],
         self::DOTTED => ['-.->', '-. %s .-> '],
         self::THICK  => [' ==> ', ' == %s ==> '],
     ];
 
-    protected int    $style = self::ARROW;
-    protected string $text  = '';
-    protected Node   $sourceNode;
-    protected Node   $targetNode;
+    private int    $style = self::ARROW;
+    private string $text  = '';
+    private Node   $sourceNode;
+    private Node   $targetNode;
 
     public function __construct(Node $sourceNode, Node $targetNode, string $text = '', int $style = self::ARROW)
     {

--- a/src/Node.php
+++ b/src/Node.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\MermaidPHP;
 
-class Node
+final class Node
 {
     public const SQUARE            = '[%s]';
     public const ROUND             = '(%s)';
@@ -32,14 +32,14 @@ class Node
     public const SUBROUTINE        = '[[%s]]';
     public const STADIUM           = '([%s])';
 
-    private static bool $safeMode   = false;
-    protected string    $identifier = '';
-    protected string    $title      = '';
-    protected string    $form       = self::ROUND;
+    private static bool $safeMode = false;
+    private string    $identifier = '';
+    private string    $title      = '';
+    private string    $form       = self::ROUND;
 
     public function __construct(string $identifier, string $title = '', string $form = self::ROUND)
     {
-        $this->identifier = static::isSafeMode() ? Helper::getId($identifier) : $identifier;
+        $this->identifier = self::isSafeMode() ? Helper::getId($identifier) : $identifier;
         $this->setTitle($title === '' ? $identifier : $title);
         $this->setForm($form);
     }

--- a/src/Render.php
+++ b/src/Render.php
@@ -20,7 +20,7 @@ use JBZoo\MermaidPHP\ClassDiagram\ClassDiagram;
 use JBZoo\MermaidPHP\ERDiagram\ERDiagram;
 use JBZoo\MermaidPHP\Timeline\Timeline;
 
-class Render
+final class Render
 {
     public const THEME_DEFAULT = 'default';
     public const THEME_FOREST  = 'forest';
@@ -87,12 +87,12 @@ class Render
 
             $title !== '' ? "<h1>{$title}</h1><hr>" : '',
 
-            '    <div class="mermaid" style="margin-top:20px;">' . $graph . '</div>',
+            '    <div class="mermaid" style="margin-top:20px;">' . $graph->__toString() . '</div>',
 
             $debugCode,
 
-            $showZoom ?
-                "<input type=\"button\" class=\"btn btn-primary\" id=\"zoom\" value=\"Zoom In\">
+            $showZoom
+                ? "<input type=\"button\" class=\"btn btn-primary\" id=\"zoom\" value=\"Zoom In\">
                 <script>
                     document.addEventListener('MermaidLoaded', function () {
                         mermaid.initialize({$mermaidParams});

--- a/src/Timeline/Event.php
+++ b/src/Timeline/Event.php
@@ -18,14 +18,14 @@ namespace JBZoo\MermaidPHP\Timeline;
 
 use JBZoo\MermaidPHP\Helper;
 
-class Event
+final class Event
 {
-    private static bool $safeMode   = false;
-    protected string    $identifier = '';
+    private static bool $safeMode = false;
+    private string    $identifier = '';
 
     public function __construct(string $identifier)
     {
-        $this->identifier = static::isSafeMode() ? Helper::getId($identifier) : $identifier;
+        $this->identifier = self::isSafeMode() ? Helper::getId($identifier) : $identifier;
     }
 
     public function __toString(): string

--- a/src/Timeline/Exception/SectionHasNoTitleException.php
+++ b/src/Timeline/Exception/SectionHasNoTitleException.php
@@ -16,6 +16,6 @@ declare(strict_types=1);
 
 namespace JBZoo\MermaidPHP\Timeline\Exception;
 
-class SectionHasNoTitleException extends \Exception
+final class SectionHasNoTitleException extends \Exception
 {
 }

--- a/src/Timeline/Marker.php
+++ b/src/Timeline/Marker.php
@@ -18,20 +18,20 @@ namespace JBZoo\MermaidPHP\Timeline;
 
 use JBZoo\MermaidPHP\Helper;
 
-class Marker
+final class Marker
 {
-    private static bool $safeMode   = false;
-    protected string    $identifier = '';
+    private static bool $safeMode = false;
+    private string    $identifier = '';
 
     /** @var Event[] */
-    protected array      $events = [];
+    private array      $events = [];
 
     /**
      * @param Event[] $events
      */
     public function __construct(string $identifier, array $events = [])
     {
-        $this->identifier = static::isSafeMode() ? Helper::getId($identifier) : $identifier;
+        $this->identifier = self::isSafeMode() ? Helper::getId($identifier) : $identifier;
         $this->setEvents($events);
     }
 

--- a/src/Timeline/Timeline.php
+++ b/src/Timeline/Timeline.php
@@ -20,18 +20,18 @@ use JBZoo\MermaidPHP\Helper;
 use JBZoo\MermaidPHP\Render;
 use JBZoo\MermaidPHP\Timeline\Exception\SectionHasNoTitleException;
 
-class Timeline
+final class Timeline
 {
     private const RENDER_SHIFT = 4;
 
     /** @var Timeline[] */
-    protected array $sections = [];
+    private array $sections = [];
 
     /** @var Marker[] */
-    protected array $markers = [];
+    private array $markers = [];
 
     /** @var mixed[] */
-    protected array $params = [
+    private array $params = [
         'title' => '',
     ];
 
@@ -110,10 +110,10 @@ class Timeline
 
             foreach ($this->markers as $marker) {
                 $tmpMarker   = [];
-                $tmpMarker[] = $spacesSub . $marker;
+                $tmpMarker[] = $spacesSub . $marker->__toString();
 
                 $events = $marker->getEvents();
-                if ([] != $events) {
+                if ($events !== []) {
                     foreach ($events as $event) {
                         $tmpMarker[] = $event;
                     }

--- a/tests/ERDiagramTest.php
+++ b/tests/ERDiagramTest.php
@@ -476,7 +476,7 @@ final class ERDiagramTest extends PHPUnit
     {
         \file_put_contents(
             PROJECT_ROOT . '/build/index.html',
-            $diagram->renderHtml(['debug' => true, 'title' => $this->getName()]),
+            $diagram->renderHtml(['debug' => true, 'title' => $this->name()]),
         );
     }
 }

--- a/tests/FlowchartTest.php
+++ b/tests/FlowchartTest.php
@@ -238,8 +238,8 @@ final class FlowchartTest extends PHPUnit
             '        9d5ed678fe57bcca610140957afab571-->0d61f8370cad1d412f80b84d143e1257;',
             '        0d61f8370cad1d412f80b84d143e1257-->|"A double quote:#quot;"|f623e75af30e62bbd73d6df5b50bb7b5;',
             '        0d61f8370cad1d412f80b84d143e1257-->|"A dec char:#hearts;"|3a3ea00cfc35332cedf6e5e9a32e94da;',
-            '        7fc56270e7a70fa81a5935b72eacbe29-->' .
-            '|"Link text<br>/\!@#$%^#amp;*()_+><\' #quot;"|9d5ed678fe57bcca610140957afab571;',
+            '        7fc56270e7a70fa81a5935b72eacbe29-->'
+            . '|"Link text<br>/\!@#$%^#amp;*()_+><\' #quot;"|9d5ed678fe57bcca610140957afab571;',
             '    end',
             '    subgraph "Problematic workflow"',
             '        c42bbd90740264d115048a82c9a10214("Alone");',
@@ -518,7 +518,7 @@ final class FlowchartTest extends PHPUnit
     {
         \file_put_contents(
             PROJECT_ROOT . '/build/index.html',
-            $graph->renderHtml(['debug' => true, 'title' => $this->getName()]),
+            $graph->renderHtml(['debug' => true, 'title' => $this->name()]),
         );
     }
 }

--- a/tests/TimelineTest.php
+++ b/tests/TimelineTest.php
@@ -162,7 +162,7 @@ final class TimelineTest extends PHPUnit
     {
         \file_put_contents(
             PROJECT_ROOT . '/build/index.html',
-            $timeline->renderHtml(['debug' => true, 'title' => $this->getName()]),
+            $timeline->renderHtml(['debug' => true, 'title' => $this->name()]),
         );
     }
 }


### PR DESCRIPTION
- Update PHP requirement to 8.2 and add PHP 8.4 to CI matrix.
- Upgrade jbzoo/toolbox-dev to version 7.3.
- Refactor internal classes to be final and use private properties for improved encapsulation and immutability.
- Update GitHub Actions:
  - Upgrade actions/upload-artifact to v4.
  - Add 'contents: read' permission.
  - Remove scheduled workflow runs.
- Adjust PHPUnit test method calls for compatibility.