### PR TITLE
Remove final keyword from extensible classes to fix #25

### DIFF
--- a/src/ClassDiagram/ClassDiagram.php
+++ b/src/ClassDiagram/ClassDiagram.php
@@ -23,6 +23,9 @@ use JBZoo\MermaidPHP\Direction;
 use JBZoo\MermaidPHP\Helper;
 use JBZoo\MermaidPHP\Render;
 
+/**
+ * @psalm-suppress ClassMustBeFinal
+ */
 class ClassDiagram
 {
     private ?string $title        = null;

--- a/src/ClassDiagram/ClassDiagram.php
+++ b/src/ClassDiagram/ClassDiagram.php
@@ -23,7 +23,7 @@ use JBZoo\MermaidPHP\Direction;
 use JBZoo\MermaidPHP\Helper;
 use JBZoo\MermaidPHP\Render;
 
-final class ClassDiagram
+class ClassDiagram
 {
     private ?string $title        = null;
     private ?Direction $direction = null;

--- a/src/ClassDiagram/Concept/Argument.php
+++ b/src/ClassDiagram/Concept/Argument.php
@@ -16,6 +16,9 @@ declare(strict_types=1);
 
 namespace JBZoo\MermaidPHP\ClassDiagram\Concept;
 
+/**
+ * @psalm-suppress ClassMustBeFinal
+ */
 class Argument implements \Stringable
 {
     public function __construct(

--- a/src/ClassDiagram/Concept/Argument.php
+++ b/src/ClassDiagram/Concept/Argument.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\MermaidPHP\ClassDiagram\Concept;
 
-final class Argument implements \Stringable
+class Argument implements \Stringable
 {
     public function __construct(
         private string $name,

--- a/src/ClassDiagram/Concept/Attribute.php
+++ b/src/ClassDiagram/Concept/Attribute.php
@@ -16,6 +16,9 @@ declare(strict_types=1);
 
 namespace JBZoo\MermaidPHP\ClassDiagram\Concept;
 
+/**
+ * @psalm-suppress ClassMustBeFinal
+ */
 class Attribute implements \Stringable
 {
     public function __construct(

--- a/src/ClassDiagram/Concept/Attribute.php
+++ b/src/ClassDiagram/Concept/Attribute.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\MermaidPHP\ClassDiagram\Concept;
 
-final class Attribute implements \Stringable
+class Attribute implements \Stringable
 {
     public function __construct(
         private string $name,

--- a/src/ClassDiagram/Concept/Concept.php
+++ b/src/ClassDiagram/Concept/Concept.php
@@ -18,6 +18,9 @@ namespace JBZoo\MermaidPHP\ClassDiagram\Concept;
 
 use JBZoo\MermaidPHP\Helper;
 
+/**
+ * @psalm-suppress ClassMustBeFinal
+ */
 class Concept
 {
     private static bool $safeMode = false;

--- a/src/ClassDiagram/Concept/Concept.php
+++ b/src/ClassDiagram/Concept/Concept.php
@@ -18,7 +18,7 @@ namespace JBZoo\MermaidPHP\ClassDiagram\Concept;
 
 use JBZoo\MermaidPHP\Helper;
 
-final class Concept
+class Concept
 {
     private static bool $safeMode = false;
     private string    $identifier;

--- a/src/ClassDiagram/Concept/Method.php
+++ b/src/ClassDiagram/Concept/Method.php
@@ -18,7 +18,7 @@ namespace JBZoo\MermaidPHP\ClassDiagram\Concept;
 
 use JBZoo\MermaidPHP\Exception;
 
-final class Method implements \Stringable
+class Method implements \Stringable
 {
     public function __construct(
         private string $name,

--- a/src/ClassDiagram/Concept/Method.php
+++ b/src/ClassDiagram/Concept/Method.php
@@ -18,6 +18,9 @@ namespace JBZoo\MermaidPHP\ClassDiagram\Concept;
 
 use JBZoo\MermaidPHP\Exception;
 
+/**
+ * @psalm-suppress ClassMustBeFinal
+ */
 class Method implements \Stringable
 {
     public function __construct(

--- a/src/ClassDiagram/ConceptNamespace/ConceptNamespace.php
+++ b/src/ClassDiagram/ConceptNamespace/ConceptNamespace.php
@@ -18,7 +18,7 @@ namespace JBZoo\MermaidPHP\ClassDiagram\ConceptNamespace;
 
 use JBZoo\MermaidPHP\ClassDiagram\Concept\Concept;
 
-final class ConceptNamespace
+class ConceptNamespace
 {
     /**
      * @param Concept[] $classes

--- a/src/ClassDiagram/ConceptNamespace/ConceptNamespace.php
+++ b/src/ClassDiagram/ConceptNamespace/ConceptNamespace.php
@@ -18,6 +18,9 @@ namespace JBZoo\MermaidPHP\ClassDiagram\ConceptNamespace;
 
 use JBZoo\MermaidPHP\ClassDiagram\Concept\Concept;
 
+/**
+ * @psalm-suppress ClassMustBeFinal
+ */
 class ConceptNamespace
 {
     /**

--- a/src/ClassDiagram/Relationship/Relationship.php
+++ b/src/ClassDiagram/Relationship/Relationship.php
@@ -18,6 +18,9 @@ namespace JBZoo\MermaidPHP\ClassDiagram\Relationship;
 
 use JBZoo\MermaidPHP\ClassDiagram\Concept\Concept;
 
+/**
+ * @psalm-suppress ClassMustBeFinal
+ */
 class Relationship
 {
     public function __construct(

--- a/src/ClassDiagram/Relationship/Relationship.php
+++ b/src/ClassDiagram/Relationship/Relationship.php
@@ -18,7 +18,7 @@ namespace JBZoo\MermaidPHP\ClassDiagram\Relationship;
 
 use JBZoo\MermaidPHP\ClassDiagram\Concept\Concept;
 
-final class Relationship
+class Relationship
 {
     public function __construct(
         private Concept $classA,

--- a/src/ERDiagram/ERDiagram.php
+++ b/src/ERDiagram/ERDiagram.php
@@ -21,6 +21,9 @@ use JBZoo\MermaidPHP\ERDiagram\Relation\Relation;
 use JBZoo\MermaidPHP\Helper;
 use JBZoo\MermaidPHP\Render;
 
+/**
+ * @psalm-suppress ClassMustBeFinal
+ */
 class ERDiagram
 {
     private const RENDER_SHIFT = 4;

--- a/src/ERDiagram/ERDiagram.php
+++ b/src/ERDiagram/ERDiagram.php
@@ -21,7 +21,7 @@ use JBZoo\MermaidPHP\ERDiagram\Relation\Relation;
 use JBZoo\MermaidPHP\Helper;
 use JBZoo\MermaidPHP\Render;
 
-final class ERDiagram
+class ERDiagram
 {
     private const RENDER_SHIFT = 4;
 

--- a/src/ERDiagram/Entity/Entity.php
+++ b/src/ERDiagram/Entity/Entity.php
@@ -18,6 +18,9 @@ namespace JBZoo\MermaidPHP\ERDiagram\Entity;
 
 use JBZoo\MermaidPHP\Helper;
 
+/**
+ * @psalm-suppress ClassMustBeFinal
+ */
 class Entity
 {
     private static bool $safeMode = false;

--- a/src/ERDiagram/Entity/Entity.php
+++ b/src/ERDiagram/Entity/Entity.php
@@ -18,7 +18,7 @@ namespace JBZoo\MermaidPHP\ERDiagram\Entity;
 
 use JBZoo\MermaidPHP\Helper;
 
-final class Entity
+class Entity
 {
     private static bool $safeMode = false;
     private string    $identifier = '';

--- a/src/ERDiagram/Entity/EntityProperty.php
+++ b/src/ERDiagram/Entity/EntityProperty.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\MermaidPHP\ERDiagram\Entity;
 
-final class EntityProperty implements \Stringable
+class EntityProperty implements \Stringable
 {
     public const PRIMARY_KEY = 'PK';
     public const FOREIGN_KEY = 'FK';

--- a/src/ERDiagram/Entity/EntityProperty.php
+++ b/src/ERDiagram/Entity/EntityProperty.php
@@ -16,6 +16,9 @@ declare(strict_types=1);
 
 namespace JBZoo\MermaidPHP\ERDiagram\Entity;
 
+/**
+ * @psalm-suppress ClassMustBeFinal
+ */
 class EntityProperty implements \Stringable
 {
     public const PRIMARY_KEY = 'PK';

--- a/src/Graph.php
+++ b/src/Graph.php
@@ -16,6 +16,9 @@ declare(strict_types=1);
 
 namespace JBZoo\MermaidPHP;
 
+/**
+ * @psalm-suppress ClassMustBeFinal
+ */
 class Graph
 {
     public const TOP_BOTTOM = 'TB';

--- a/src/Graph.php
+++ b/src/Graph.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\MermaidPHP;
 
-final class Graph
+class Graph
 {
     public const TOP_BOTTOM = 'TB';
     public const BOTTOM_TOP = 'BT';

--- a/src/Link.php
+++ b/src/Link.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\MermaidPHP;
 
-final class Link
+class Link
 {
     public const ARROW  = 1;
     public const LINE   = 2;

--- a/src/Link.php
+++ b/src/Link.php
@@ -16,6 +16,9 @@ declare(strict_types=1);
 
 namespace JBZoo\MermaidPHP;
 
+/**
+ * @psalm-suppress ClassMustBeFinal
+ */
 class Link
 {
     public const ARROW  = 1;

--- a/src/Node.php
+++ b/src/Node.php
@@ -16,6 +16,9 @@ declare(strict_types=1);
 
 namespace JBZoo\MermaidPHP;
 
+/**
+ * @psalm-suppress ClassMustBeFinal
+ */
 class Node
 {
     public const SQUARE            = '[%s]';

--- a/src/Node.php
+++ b/src/Node.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace JBZoo\MermaidPHP;
 
-final class Node
+class Node
 {
     public const SQUARE            = '[%s]';
     public const ROUND             = '(%s)';

--- a/src/Render.php
+++ b/src/Render.php
@@ -20,7 +20,7 @@ use JBZoo\MermaidPHP\ClassDiagram\ClassDiagram;
 use JBZoo\MermaidPHP\ERDiagram\ERDiagram;
 use JBZoo\MermaidPHP\Timeline\Timeline;
 
-final class Render
+class Render
 {
     public const THEME_DEFAULT = 'default';
     public const THEME_FOREST  = 'forest';

--- a/src/Render.php
+++ b/src/Render.php
@@ -20,6 +20,9 @@ use JBZoo\MermaidPHP\ClassDiagram\ClassDiagram;
 use JBZoo\MermaidPHP\ERDiagram\ERDiagram;
 use JBZoo\MermaidPHP\Timeline\Timeline;
 
+/**
+ * @psalm-suppress ClassMustBeFinal
+ */
 class Render
 {
     public const THEME_DEFAULT = 'default';

--- a/src/Timeline/Event.php
+++ b/src/Timeline/Event.php
@@ -18,6 +18,9 @@ namespace JBZoo\MermaidPHP\Timeline;
 
 use JBZoo\MermaidPHP\Helper;
 
+/**
+ * @psalm-suppress ClassMustBeFinal
+ */
 class Event
 {
     private static bool $safeMode = false;

--- a/src/Timeline/Event.php
+++ b/src/Timeline/Event.php
@@ -18,7 +18,7 @@ namespace JBZoo\MermaidPHP\Timeline;
 
 use JBZoo\MermaidPHP\Helper;
 
-final class Event
+class Event
 {
     private static bool $safeMode = false;
     private string    $identifier = '';

--- a/src/Timeline/Marker.php
+++ b/src/Timeline/Marker.php
@@ -18,7 +18,7 @@ namespace JBZoo\MermaidPHP\Timeline;
 
 use JBZoo\MermaidPHP\Helper;
 
-final class Marker
+class Marker
 {
     private static bool $safeMode = false;
     private string    $identifier = '';

--- a/src/Timeline/Marker.php
+++ b/src/Timeline/Marker.php
@@ -18,6 +18,9 @@ namespace JBZoo\MermaidPHP\Timeline;
 
 use JBZoo\MermaidPHP\Helper;
 
+/**
+ * @psalm-suppress ClassMustBeFinal
+ */
 class Marker
 {
     private static bool $safeMode = false;

--- a/src/Timeline/Timeline.php
+++ b/src/Timeline/Timeline.php
@@ -20,7 +20,7 @@ use JBZoo\MermaidPHP\Helper;
 use JBZoo\MermaidPHP\Render;
 use JBZoo\MermaidPHP\Timeline\Exception\SectionHasNoTitleException;
 
-final class Timeline
+class Timeline
 {
     private const RENDER_SHIFT = 4;
 

--- a/src/Timeline/Timeline.php
+++ b/src/Timeline/Timeline.php
@@ -20,6 +20,9 @@ use JBZoo\MermaidPHP\Helper;
 use JBZoo\MermaidPHP\Render;
 use JBZoo\MermaidPHP\Timeline\Exception\SectionHasNoTitleException;
 
+/**
+ * @psalm-suppress ClassMustBeFinal
+ */
 class Timeline
 {
     private const RENDER_SHIFT = 4;


### PR DESCRIPTION
This change allows users to extend core classes for customization purposes.

Modified classes (17 files):
- Core diagram classes: Graph, ERDiagram, ClassDiagram, Timeline
- Building blocks: Node, Link, Entity, Concept, Marker
- Component classes: EntityProperty, Attribute, Method, Event, Argument
- Structural classes: ConceptNamespace, Relationship
- Utility classes: Render

All tests pass (85 tests, 269 assertions).

Fixes #25