### PR TITLE
Fix: Change Link class properties back to protected for extensibility.

### DIFF
--- a/src/Link.php
+++ b/src/Link.php
@@ -26,17 +26,17 @@ class Link
     public const DOTTED = 3;
     public const THICK  = 4;
 
-    private const TEMPLATES = [
+    protected const TEMPLATES = [
         self::ARROW  => ['-->', '-->|%s|'],
         self::LINE   => [' --- ', '---|%s|'],
         self::DOTTED => ['-.->', '-. %s .-> '],
         self::THICK  => [' ==> ', ' == %s ==> '],
     ];
 
-    private int    $style = self::ARROW;
-    private string $text  = '';
-    private Node   $sourceNode;
-    private Node   $targetNode;
+    protected int    $style = self::ARROW;
+    protected string $text  = '';
+    protected Node   $sourceNode;
+    protected Node   $targetNode;
 
     public function __construct(Node $sourceNode, Node $targetNode, string $text = '', int $style = self::ARROW)
     {


### PR DESCRIPTION
For issue in https://github.com/JBZoo/Mermaid-PHP/issues/27

I've simply changed the scope of the class property to `protected` to allow access in subclasses.